### PR TITLE
FIX: Prevent race condition causing log directory to go offline

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 import java.io.File
+import java.nio.channels.ClosedChannelException
 import java.util
 import java.util.{Optional, OptionalLong}
 import scala.collection._
@@ -600,6 +601,45 @@ class LogSegmentTest {
     assertEquals(overflowBytesAppended, overflowSegment.size)
 
     Utils.delete(tempDir)
+  }
+
+  /**
+   * This test simulates a race condition the can occur during replica rebalancing
+   * where a log segment's file is deleted after an asynchronous flush
+   * has been scheduled but before it executes.
+   */
+  @Test
+  def testFlushOnClosedSegmentExceptionHandling(): Unit = {
+    // Create a LogSegment
+    val segment = createSegment(0)
+
+    // Write some data to it so the file is created, then flush it to disk
+    segment.append(0L, Time.SYSTEM.milliseconds(), 0L, TestUtils.singletonRecords("foo".getBytes()))
+    segment.flush()
+
+    val logFile = segment.log.file()
+    assertTrue(logFile.exists(), "Log file should exist after creation and flush")
+
+    // Simulate an unexpected I/O error by closing the channel
+    segment.log.channel.close()
+    assertFalse(segment.log.channel.isOpen, "The log's file channel should be closed")
+
+    // Calling flush() on the segment should throw a ClosedChannelException
+    assertThrows(classOf[ClosedChannelException], () => segment.flush(),
+      "A ClosedChannelException should have been thrown")
+
+    // Simulating the log file being deleted (occur during replica rebalancing)
+    java.nio.file.Files.delete(logFile.toPath)
+    assertFalse(logFile.exists(), "Log file should not exist after deletion")
+
+    // Call flush() directly on the segment.
+    // This should catch a CloseChannelException and return gracefully.
+    try {
+      segment.flush()
+    } catch {
+      case e: ClosedChannelException =>
+        fail("LogSegment.flush() should not have thrown a ClosedChannelException on a deleted file", e)
+    }
   }
 
   private def newProducerStateManager(): ProducerStateManager = {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.FileTime;
@@ -624,17 +625,24 @@ public class LogSegment implements Closeable {
      */
     public void flush() throws IOException {
         try {
-            LOG_FLUSH_TIMER.time(new Callable<Void>() {
-                // lambdas cannot declare a more specific exception type, so we use an anonymous inner class
-                @Override
-                public Void call() throws IOException {
-                    log.flush();
-                    offsetIndex().flush();
-                    timeIndex().flush();
-                    txnIndex.flush();
-                    return null;
-                }
+            LOG_FLUSH_TIMER.time((Callable<Void>) () -> {
+                log.flush();
+                offsetIndex().flush();
+                timeIndex().flush();
+                txnIndex().flush();
+                return null;
             });
+        } catch (ClosedChannelException e) {
+            if (!log.file().exists()) {
+                // The log segment file has been moved/deleted
+                // as part of a replica movement, so this exception is safe to ignore.
+                LOGGER.warn("Caught a ClosedChannelException on a non-existent log segment file '{}'. " +
+                        "This is expected during a replica move and is safe to ignore.", log.file().getAbsolutePath());
+            } else {
+                // The file still exists, so this is an unexpected error.
+                // Re-throw it to trigger the normal failure handling.
+                throw e;
+            }
         } catch (Exception e) {
             if (e instanceof IOException)
                 throw (IOException) e;


### PR DESCRIPTION
A race condition can occur during replica rebalancing where a log segment's file is deleted after an asynchronous flush has been scheduled but before it executes.

This would previously cause an unhandled `ClosedChannelException`, leading the `ReplicaManager` to mark the entire log directory as offline.

The fix involves catching the `ClosedChannelException` within the `LogSegment.flush()` method and suppressing it only if the underlying log file no longer exists, which is the specific symptom of this race condition. Legitimate I/O errors on existing files will still be thrown.

Unit test has been added to `LogSegmentTest` to verify both the fix and the case where the exception should still be thrown.
